### PR TITLE
Make importData reload from store optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ export default Route.extend({
 `options` are:
 - `json` Boolean (default `true`)
 - `truncate` Boolean (default `true`) if `true` the existing data gets replaced.
+- `reload` Boolean (default `true`) if `true` the data gets loaded into the store after import.
 
 **exportData(types, options)**
 

--- a/addon/helpers/import-export.js
+++ b/addon/helpers/import-export.js
@@ -14,7 +14,8 @@ export function importData(store, content, options) {
   // merge defaults
   options = assign({
     json: true,
-    truncate: true
+    truncate: true,
+    reload: true
   }, options || {});
 
   let reloadTypes = [];
@@ -51,9 +52,11 @@ export function importData(store, content, options) {
   return Ember.RSVP.all(promises)
     .then(function() {
       // reload from store
-      reloadTypes.forEach(function(type) {
-        store.findAll(type);
-      });
+      if (options.reload) {
+        reloadTypes.forEach(function(type) {
+          store.findAll(type);
+        });
+      }
     });
 }
 


### PR DESCRIPTION
When importing a bunch of data, the reload from store takes awhile and stalls the app.  This allows you to load the data into localStorage, but not into the Ember store.  Adds the option `reload` (defaults to true) on importData.   